### PR TITLE
Fix dynamic background in TranslatorScreen

### DIFF
--- a/lib/screens/translator_screen.dart
+++ b/lib/screens/translator_screen.dart
@@ -188,11 +188,13 @@ class _TranslatorScreenState extends ConsumerState<TranslatorScreen> {
       ),
       body: Stack(
         children: [
-          try {
-            AssetsManager.buildBlueprintBackground(context)
-          } catch (e) {
-            AssetsManager.buildFallbackBlueprintBackground(context)
-          },
+          (() {
+            try {
+              return AssetsManager.buildBlueprintBackground(context);
+            } catch (e) {
+              return AssetsManager.buildFallbackBlueprintBackground(context);
+            }
+          })(),
           SafeArea(
             child: Column(
               children: [


### PR DESCRIPTION
### **User description**
## Summary
- handle background asset loading using a closure with try/catch

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffea436f88320b3920f6809e27fd0


___

### **PR Type**
Bug fix


___

### **Description**
- Fix background widget initialization with proper error handling

- Replace invalid try/catch block with closure returning fallback


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>translator_screen.dart</strong><dd><code>Refactor background widget initialization with error handling</code></dd></summary>
<hr>

lib/screens/translator_screen.dart

<li>Replaced invalid try/catch block with an immediately-invoked closure<br> <li> Ensured fallback background is used on error during asset loading<br> <li> Improved robustness of background widget initialization


</details>


  </td>
  <td><a href="https://github.com/Jokerman890/Polly/pull/2/files#diff-8d3cb2df21e9cbb60f23ecf90e1dd6a40a305abd23ab47859f219a0f568abd85">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>